### PR TITLE
fix(ci): go version for vulncheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: 'go.mod'
 
       - name: Scan for Vulnerabilities in Code
         uses: Templum/govulncheck-action@0eeca9d81f01facc00829cc99a14e44ce59ce80f # v1.0.2


### PR DESCRIPTION
Vulncheck step in the CI workflow relies on undefined go matrix version. Use version from go.mod instead.
