### PR TITLE
fix(ci): release process token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   GOLANGCI_LINT_VERSION: v1.62
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
The action needs to be able to create a branch. Adjust permissions for the GITHUB_TOKEN to be able to do so.
