### PR TITLE
feat(tooling): create releases in draft mode

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,7 @@
 	"pull-request-title-pattern": "release: ${version}",
 	"versioning": "prerelease",
 	"extra-label": "release",
+	"draft": true,
 	"packages": {
 		".": {
 			"release-type": "go",


### PR DESCRIPTION
Create new releases as draft so we can manually adjust release notes
with additional notes such as recommendations for addressing breaking
changes.
