### PR TITLE
fix: decode error on refund response

### DIFF
--- a/transactions.go
+++ b/transactions.go
@@ -841,12 +841,14 @@ func (c *TransactionsClient) Refund(ctx context.Context, merchantCode string, tr
 	}()
 
 	switch resp.StatusCode {
-	case http.StatusCreated:
-		var v TransactionsRefundResponse
-		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+	case http.StatusCreated:		
+		var raw json.RawMessage
+		if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
 			return nil, fmt.Errorf("decode response: %s", err.Error())
 		}
 
+		v := TransactionsRefundResponse(raw)
+		
 		return &v, nil
 	case http.StatusBadRequest:
 		var apiErr Problem


### PR DESCRIPTION
This PR fixes an unmarshaling error that happens when the Refund endpoint returns an empty `{}` body.

I just changed the code to decode into a standard `json.RawMessage` first. Now it works perfectly on my end.

As mentioned in the issue #308 , there are a few other types in `checkouts.go` and `customers.go` that might need a similar adjustment, but I only touched the Refund endpoint for now to get it working again.