### PR TITLE
fix(codegen): handle arbitrary object type responses

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1326,7 +1326,7 @@ type CheckoutsCreateApplePaySessionParams struct {
 CheckoutsCreateApplePaySessionResponse is a schema definition.
 
 ```go
-type CheckoutsCreateApplePaySessionResponse json.RawMessage
+type CheckoutsCreateApplePaySessionResponse = json.RawMessage
 ```
 
 <a name="CheckoutsCreateParams"></a>
@@ -5801,7 +5801,7 @@ type TransactionsRefundParams struct {
 TransactionsRefundResponse is a schema definition.
 
 ```go
-type TransactionsRefundResponse json.RawMessage
+type TransactionsRefundResponse = json.RawMessage
 ```
 
 <a name="Unauthorized"></a>

--- a/checkouts.go
+++ b/checkouts.go
@@ -527,7 +527,7 @@ func (p *CheckoutsListAvailablePaymentMethodsParams) QueryValues() url.Values {
 type CheckoutsListResponse []CheckoutSuccess
 
 // CheckoutsCreateApplePaySessionResponse is a schema definition.
-type CheckoutsCreateApplePaySessionResponse json.RawMessage
+type CheckoutsCreateApplePaySessionResponse = json.RawMessage
 
 // CheckoutsCreateApplePaySession400Response is a schema definition.
 type CheckoutsCreateApplePaySession400Response json.RawMessage

--- a/internal/cmd/codegen/pkg/builder/intermediate_representation.go
+++ b/internal/cmd/codegen/pkg/builder/intermediate_representation.go
@@ -14,6 +14,8 @@ type TypeDeclaration struct {
 	Name string
 	// Type describes the type of the type (e.g. struct, int64, string)
 	Type string
+	// Alias indicates whether the declaration aliases Type instead of defining a new type.
+	Alias bool
 	// Fields holds the information for the field
 	Fields []StructField
 	// Comment holds the description of the type

--- a/internal/cmd/codegen/pkg/builder/transform.go
+++ b/internal/cmd/codegen/pkg/builder/transform.go
@@ -429,6 +429,7 @@ func (b *Builder) generateSchemaComponents(name string, schema *base.SchemaProxy
 				Comment: schemaGodoc(name, spec),
 				Type:    "json.RawMessage",
 				Name:    name,
+				Alias:   !isErr,
 				Schema:  spec,
 			}
 			types = append(types, typ)

--- a/internal/cmd/codegen/pkg/builder/types.go
+++ b/internal/cmd/codegen/pkg/builder/types.go
@@ -21,7 +21,11 @@ func (tt *TypeDeclaration) String() string {
 	if tt.Comment != "" {
 		fmt.Fprintf(buf, "// %s\n", tt.Comment)
 	}
-	fmt.Fprintf(buf, "type %s %s", tt.Name, tt.Type)
+	fmt.Fprintf(buf, "type %s ", tt.Name)
+	if tt.Alias {
+		fmt.Fprint(buf, "= ")
+	}
+	fmt.Fprint(buf, tt.Type)
 	if tt.Fields != nil {
 		slices.SortFunc(tt.Fields, func(a, b StructField) int {
 			return strings.Compare(a.Name, b.Name)

--- a/transactions.go
+++ b/transactions.go
@@ -710,7 +710,7 @@ type TransactionsListResponse struct {
 }
 
 // TransactionsRefundResponse is a schema definition.
-type TransactionsRefundResponse json.RawMessage
+type TransactionsRefundResponse = json.RawMessage
 
 // TransactionsClient provides access to the Transactions API.
 //


### PR DESCRIPTION
Fix typing for arbitrary object responses. I.e. `type: object` without properties. Previously, we defined such responses as a new type with `type Response json.RawMessage` which would loose the `json.Unmarshaller` implementation of `json.RawMessage`. Change it to type alias `type Response = json.RawMessage` to keep the unmarshal behavior.

Fixes: https://github.com/sumup/sumup-go/issues/308
