### PR TITLE
feat!: bump minimum supported version of go to 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,9 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1.24" # stable-2
-          - "1.25" # stable-1
-          - "stable" # 1.26
+          - "1.25" # stable-2
+          - "1.26" # stable-1
+          - "stable" # 1.27
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/sumup/sumup-go
 
-go 1.24.0
+go 1.25.0
 
 require golang.org/x/oauth2 v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
-golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
 golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=


### PR DESCRIPTION
[Go 1.27](https://go.dev/doc/go1.27) is out and with that we are bumping our minimum support version of go to [1.25](https://go.dev/doc/go1.25).